### PR TITLE
Allow the user to set a custom (local) image for the canvas' background

### DIFF
--- a/src/components/common/Settings/BackgroundSettings.tsx
+++ b/src/components/common/Settings/BackgroundSettings.tsx
@@ -11,6 +11,10 @@ export const BackgroundSettings = view(() => {
         app.canvasStyles.backgroundType = ((e.target as HTMLElement).innerText as CanvasBackgroundTypes);
     };
 
+    const handleBgImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+        app.canvasStyles.bgImage = URL.createObjectURL(e.target.files[0]);
+    }
+
     return (
         <>
             <div className="btn-group btn-group-sm w-100 mb-2">
@@ -88,6 +92,11 @@ export const BackgroundSettings = view(() => {
                         />
                     </div>
                 })}
+                <div className="col">
+                    <div className={`bg-image-preview bg-image-preview--file`}>
+                        <input type="file" accept="image/*" onChange={handleBgImageUpload}></input>
+                    </div>
+                </div>
             </div>}
         </>
     )

--- a/src/components/layout/App/styles.ts
+++ b/src/components/layout/App/styles.ts
@@ -65,6 +65,25 @@ export const styles = () => {
                  &.active {
                   border-width: 2px;
                  }
+
+                 &.bg-image-preview--file {
+                    position: relative;
+                    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='white' d='M492 236H276V20c0-11.046-8.954-20-20-20s-20 8.954-20 20v216H20c-11.046 0-20 8.954-20 20s8.954 20 20 20h216v216c0 11.046 8.954 20 20 20s20-8.954 20-20V276h216c11.046 0 20-8.954 20-20s-8.954-20-20-20z'/%3E%3C/svg%3E");
+                    background-size: 40%;
+                    background-repeat: no-repeat;
+                    background-position: center;
+
+                    input[type="file"] {
+                      position: absolute;
+                      top: 0;
+                      left: 0;
+                      width: 100%;
+                      height: 100%;
+                      opacity: 0;
+                      cursor: pointer;
+                    }
+
+                  }
               }
             }
         


### PR DESCRIPTION
Fixes #13

Just added a simple `input[type="file"]` to let the user select the image for the canvas' background.
Made this the 5th button in the background-image selection area (with a _plus_ icon).

So the background-image selector changed from:

<img width="436" alt="Screenshot 2020-08-23 at 9 48 36 PM" src="https://user-images.githubusercontent.com/7734410/90983487-3d02d780-e58c-11ea-8dfe-35fe4292dad4.png">

to:

<img width="436" alt="Screenshot 2020-08-23 at 9 48 16 PM" src="https://user-images.githubusercontent.com/7734410/90983493-4a1fc680-e58c-11ea-8f5f-1be0e978e5ab.png">
