### PR TITLE
Web Share Target API Support

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -16,5 +16,12 @@
     "theme_color": "#a090c1",
     "background_color": "#a090c1",
     "display": "standalone",
-    "start_url": "https://screenshot.rocks?start=pwa"
+    "start_url": "https://screenshot.rocks?start=pwa",
+    "share_target": {
+        "action": "/",
+        "method": "GET",
+        "params": {
+          "text": "text"
+        }
+      }
 }

--- a/src/components/common/ImageSelector/index.tsx
+++ b/src/components/common/ImageSelector/index.tsx
@@ -84,6 +84,7 @@ export const ImageSelector = view(() => {
                     type="text"
                     className={`form-control ${urlIsInvalid || requestFailed ? 'is-invalid' : ''}`}
                     placeholder="https://your-website.com"
+                    value={urlValue}
                 />
                 <div className="input-group-text">
                     <label htmlFor="mobile">Mobile</label>

--- a/src/components/common/ImageSelector/index.tsx
+++ b/src/components/common/ImageSelector/index.tsx
@@ -7,7 +7,15 @@ import {validURL} from "../../../utils/url";
 import {routeStore} from "../../../stores/routeStore";
 
 export const ImageSelector = view(() => {
-    const [urlValue, setUrlValue] = useState(null);
+    const existingUrl = () => {
+        const parsedUrl = new URL(window.location.href);
+        if(parsedUrl.searchParams.get('text')){
+            return parsedUrl.searchParams.get('text');
+        }
+        return null;
+    }
+
+    const [urlValue, setUrlValue] = useState(existingUrl());
     const [urlIsInvalid, setUrlIsInvalid] = useState(false);
     const [urlLoading, setUrlLoading] = useState(false);
     const [requestFailed, setRequestFailed] = useState(false);


### PR DESCRIPTION
Hi, 

I've added support for the Web Share Target API for the screenshot.rocks PWA.

This means on Android the screenshot.rocks PWA will appear in the list of apps you can share data to.

Example: Sharing a page in Chrome to screenshot.rocks will launch the PWA and prepopulate the form with the URL.