### PR TITLE
feat: update margin-right on window controls

### DIFF
--- a/src/components/common/Frames/Browser/styles.ts
+++ b/src/components/common/Frames/Browser/styles.ts
@@ -144,7 +144,7 @@ export const styles = (props: ICanvasProps): string => {
           width: ${determineWidth(15)}px;
           height: ${determineWidth(15)}px;
           border-radius: 50px;
-          margin-right: ${determineWidth(3)}px;
+          margin-right: ${determineWidth(8)}px;
           &.close {
             background: ${styleVars.closeButtonColor};
             opacity: 1;

--- a/src/components/common/Frames/Browser/styles.ts
+++ b/src/components/common/Frames/Browser/styles.ts
@@ -144,7 +144,7 @@ export const styles = (props: ICanvasProps): string => {
           width: ${determineWidth(15)}px;
           height: ${determineWidth(15)}px;
           border-radius: 50px;
-          margin-right: ${determineWidth(8)}px;
+          margin-right: ${determineWidth(9)}px;
           &.close {
             background: ${styleVars.closeButtonColor};
             opacity: 1;


### PR DESCRIPTION
This pull request introduces a minor style change that updates the `margin-right` on `.window-control .span` to more accurately reflect an actual MacOS window control style. 

`9px` is the sweet spot, I double-checked ; )